### PR TITLE
APM-2677 updates to return empty bundle

### DIFF
--- a/sandbox/src/mock-api.js
+++ b/sandbox/src/mock-api.js
@@ -35,7 +35,7 @@ app.get("/FHIR/R4/Observation", (req, res) => {
   const nhsNumberNotFoundPattern = "^https:\/\/fhir.nhs.uk\/Id\/nhs-number[|]1000000000$";
   let nhsNumberNotFound = new RegExp(nhsNumberNotFoundPattern);
 
-  if (req.query["patient.identifier"] & nhsNumberNotFound.test(req.query["patient.identifier"])) {
+  if (req.query["patient.identifier"].split("|")[1] === "9000000033") {
     let responseBody = {
       resourceType: "Bundle",
       id: "1a420b58-5b91-4706-9a7c-90028ca79ff3",

--- a/specification/covid-19-test-result.yaml
+++ b/specification/covid-19-test-result.yaml
@@ -162,7 +162,9 @@ paths:
         | Scenario                      | Request                                                              | Response                                   |
         | ----------------------------- | -------------------------------------------------------------------- | ------------------------------------------ |
         | COVID-19 test history found   | `patient.identifier`=`https://fhir.nhs.uk/Id/nhs-number\|9000000009` | HTTP Status 200 with test results data in response body |
-        | No test results found         | `patient.identifier`= anything else                                  | HTTP Status 200 with empty bundle in response body |
+        | No test results found         | `patient.identifier`=`https://fhir.nhs.uk/Id/nhs-number\|9000000033` | HTTP Status 200 with empty bundle in response body |
+        | Bad Request                   | `patient.identifier`= anything else                                  | HTTP Status 400 Bad Request |
+
         You can try out the sandbox using the 'Try this API' feature on this page.
       parameters:
         - in: header


### PR DESCRIPTION
## Summary
To bring the sandbox behaviour inline with the spec (empty bundle 200 resp on patient id with little data)